### PR TITLE
Skip the publish test coverage command, now handled in pytest-azurepipelines plugin

### DIFF
--- a/.azure-pipelines/jobs/test.yml
+++ b/.azure-pipelines/jobs/test.yml
@@ -43,9 +43,3 @@ jobs:
 
   - script: tox --installpkg $(WHEEL)
     displayName: Run tox tests
-
-  - task: PublishCodeCoverageResults@1
-    inputs:
-      codeCoverageTool: Cobertura
-      summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
-      reportDirectory: '$(System.DefaultWorkingDirectory)/**/htmlcov'


### PR DESCRIPTION
Raising the PR to validate the result is the same as before